### PR TITLE
PA-926 Enable various eslint rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,2 @@
+// enable eslint for this repo itself
+module.exports = require('.');

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,44 @@
+# This action publishes a package after you push a version number tag
+name: Publish to GitHub Packages, create GitHub Release
+on:
+  push:
+    tags:
+      # filter to tags that look like a version
+      # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-branches-and-tags
+      - 'v[0-9]*'
+permissions:
+  contents: write # for gh-release
+  packages: write # for npm publish
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    permissions: 
+      contents: read
+      packages: write 
+    steps:
+      - uses: actions/checkout@v3
+        # since trigger is not a branch event, it will check out master
+      - uses: actions/setup-node@v3
+        # Setup .npmrc file to publish to GitHub Packages
+        with:
+          cache: 'npm'
+          node-version: '16'
+          # create .npmrc with @themaven-net:registry=https://npm.pkg.github.com/
+          scope: '@themaven-net'
+          registry-url: 'https://npm.pkg.github.com'
+      - run: npm ci
+      - run: npm test
+      - run: |
+          VERSION=$(jq <package.json .version)
+          EXPECTED_TAG=refs/tags/v$VERSION
+          if [[ "$GITHUB_REF" != "$EXPECTED_TAG" ]]; then
+            echo >&2 "Error: the pushed ref $GITHUB_REF did not match package.json $VERSION; aborting npm publish"
+            exit 2
+          fi
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Release
+        uses: softprops/action-gh-release@v0.1.14
+        with:
+          generate_release_notes: true

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,20 @@
+name: tests
+
+# triggers
+# https://docs.github.com/en/actions/reference/events-that-trigger-workflows
+on:
+  push:
+  pull_request:
+jobs:
+  run-lint:
+    # available runners:
+    # https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idruns-on
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'npm'
+      - run: npm ci
+      - run: npm test

--- a/README.md
+++ b/README.md
@@ -64,3 +64,18 @@ module.exports = require('@themaven-net/eslint-config-maven/.prettierjs');
 * [eslint-plugin-node](https://www.npmjs.com/package/eslint-plugin-node): Additional ESLint's rules for Node.js.
 * [eslint-plugin-promise](https://www.npmjs.com/package/eslint-plugin-promise): Enforce best practices for JavaScript promises.
 * [eslint-plugin-import](https://www.npmjs.com/package/eslint-plugin-import): ESLint plugin with rules that help validate proper imports.
+
+## Developing
+
+To make a release, push a git tag with the version:
+
+```sh
+git checkout master
+npm version major|minor|patch --message '%s ...'
+git push master --follow-tags
+```
+
+The GitHub workflow
+[npm-publish.yml](./.github/workflows/npm-publish.yml)
+will then publish the npm package to GitHub Packages
+and create a GitHub Release.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# eslint-config-maven
+# @themaven-net/eslint-config-maven
 
 > Say Media's eslint / prettier config
 
@@ -19,26 +19,36 @@ Steps:
 
 ## Installation
 
-Install [eslint](https://eslint.org/) and `eslint-config-maven`:
+First, [authenticate the GitHub npm registry](https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-npm-registry).
+To do this, navigate to GitHub → Settings → Developer settings → Personal access tokens.
+Click Generate new token. Add “repo” and “read:packages” permissions.
+Generate the token.
+In the terminal, set up `~/.npmrc` by running
+`npm login --scope=@themaven-net --registry=https://npm.pkg.github.com`,
+use your GitHub username as the username, and use the token as the password
+(warning: this deletes all the comments in `~/.npmrc`!).
+Back in the browser, click “Configure SSO → Authorize” to give the token access to Maven.
+
+Install [eslint](https://eslint.org/) and `@themaven-net/eslint-config-maven`:
 
 ```
-npm install --save-dev eslint themaven-net/eslint-config-maven
+npm install --save-dev eslint @themaven-net/eslint-config-maven
 ```
 
 ## Usage
 
-If you've installed `eslint-config-maven` locally within your project, just set your `eslint` config to:
+If you've installed `@themaven-net/eslint-config-maven` locally within your project, just set your `.eslintrc.js` config to:
 
 ```json
-{
-  "extends": "maven"
-}
+module.exports = {
+  extends: '@themaven-net/maven' // requires '@themaven-net/eslint-config-maven'
+};
 ```
 
 For using our Prettier defaults, you'll want to make a `.prettierrc.js` file with this:
 
 ```js
-module.exports = require('eslint-config-maven/.prettierjs');
+module.exports = require('@themaven-net/eslint-config-maven/.prettierjs');
 ```
 
 ## Documentation

--- a/eslint-js.js
+++ b/eslint-js.js
@@ -1,0 +1,61 @@
+module.exports = {
+    extends: ['prettier'],
+    plugins: ['prettier'],
+    env: {
+        browser: true,
+        node: true,
+    },
+    // extra globals for the Angular part of the codebase.
+    globals: {
+        angular: true,
+        define: true,
+    },
+    rules: {
+        'max-len': [
+            'error',
+            {
+                code: 110,
+                ignoreStrings: true,
+                ignoreUrls: true,
+            },
+        ],
+        'prettier/prettier': [
+            'error',
+            require('./.prettierrc'),
+        ],
+
+        // enable a subset of eslint:recommended; consider enabling all of it
+        // https://eslint.org/docs/rules/
+        // When adding a rule here, also check whether you have to add
+        // the typescript version in eslint-ts.js
+        'getter-return': 'error',
+        'no-async-promise-executor': 'error',
+        'no-compare-neg-zero': 'error',
+        'no-const-assign': 'error',
+        'no-this-before-super': 'error',
+        'no-class-assign': 'error',
+        'no-dupe-args': 'error',
+        'no-dupe-class-members': 'error',
+        'no-dupe-else-if': 'error',
+        'no-dupe-keys': 'error',
+        'no-duplicate-case': 'error',
+        'no-fallthrough': 'error',
+        'no-func-assign': 'error',
+        'no-import-assign': 'error',
+        'no-setter-return': 'error',
+        'no-sparse-arrays': 'error',
+        'use-isnan': 'error',
+
+        'one-var': 'off',
+        'spaced-comment': 'off',
+        'no-useless-escape': 'off', // TODO should probably be on, with our errors fixed
+        'prefer-promise-reject-errors': 'off', // TODO consider fixing
+        'no-unneeded-ternary': 'off', // TODO should probably be on, with our errors fixed
+        'no-useless-return': 'off',
+        'new-cap': 'off',
+        'no-path-concat': 'off',
+        'no-throw-literal': 'off', // TODO should probably be on, with our errors fixed
+        'no-template-curly-in-string': 'off',
+        yoda: 'off',
+    },
+}

--- a/eslint-js.js
+++ b/eslint-js.js
@@ -19,10 +19,7 @@ module.exports = {
                 ignoreUrls: true,
             },
         ],
-        'prettier/prettier': [
-            'error',
-            require('./.prettierrc'),
-        ],
+        'prettier/prettier': ['error', require('./.prettierrc')],
 
         // enable a subset of eslint:recommended; consider enabling all of it
         // https://eslint.org/docs/rules/
@@ -58,4 +55,4 @@ module.exports = {
         'no-template-curly-in-string': 'off',
         yoda: 'off',
     },
-}
+};

--- a/eslint-ts.js
+++ b/eslint-ts.js
@@ -1,6 +1,5 @@
 module.exports = {
     "extends": [
-        "./index.js",
         // disable eslint rules that conflict with @typescript-eslint
         'plugin:@typescript-eslint/eslint-recommended',
         // new projects should consider enabling these plugins from the start

--- a/eslint-ts.js
+++ b/eslint-ts.js
@@ -1,5 +1,5 @@
 module.exports = {
-    "extends": [
+    extends: [
         // disable eslint rules that conflict with @typescript-eslint
         'plugin:@typescript-eslint/eslint-recommended',
         // new projects should consider enabling these plugins from the start
@@ -7,16 +7,16 @@ module.exports = {
         // 'plugin:@typescript-eslint/recommended',
         // 'plugin:@typescript-eslint/recommended-requiring-type-checking',
     ],
-    "env": {
-        "node": true
+    env: {
+        node: true,
     },
-    "parser": "@typescript-eslint/parser",
-    "plugins": ["@typescript-eslint"],
-    "parserOptions": {
-        "ecmaVersion": 2020,
-        "project": ["./tsconfig.json"]
+    parser: '@typescript-eslint/parser',
+    plugins: ['@typescript-eslint'],
+    parserOptions: {
+        ecmaVersion: 2020,
+        project: ['./tsconfig.json'],
     },
-    "rules": {
+    rules: {
         // Disable opinionated rules from plugin:@typescript-eslint/eslint-recommend
         // https://github.com/typescript-eslint/typescript-eslint/blob/v5.15.0/packages/eslint-plugin/src/configs/eslint-recommended.ts
         'no-var': 'warn',
@@ -41,4 +41,4 @@ module.exports = {
         '@typescript-eslint/no-var-requires': 'error',
         '@typescript-eslint/prefer-namespace-keyword': 'error',
     },
-}
+};

--- a/eslint-ts.js
+++ b/eslint-ts.js
@@ -1,5 +1,9 @@
 module.exports = {
-    "extends": "maven",
+    "extends": [
+        "maven",
+        // disable eslint rules that conflict with @typescript-eslint
+        'plugin:@typescript-eslint/eslint-recommended',
+    ],
     "env": {
         "node": true
     },
@@ -9,5 +13,16 @@ module.exports = {
         "ecmaVersion": 2020,
         "project": ["./tsconfig.json"]
     },
-    "rules": {}
+    "rules": {
+        // Disable opinionated rules from plugin:@typescript-eslint/eslint-recommend
+        // https://github.com/typescript-eslint/typescript-eslint/blob/v5.15.0/packages/eslint-plugin/src/configs/eslint-recommended.ts
+        'no-var': 'warn',
+        'prefer-const': 'warn',
+        'prefer-rest-params': 'warn',
+        'prefer-spread': 'warn',
+
+        // Enable typescript version of rules originally from eslint
+        // https://github.com/typescript-eslint/typescript-eslint/tree/v5.15.0/packages/eslint-plugin/docs/rules#extension-rules
+        '@typescript-eslint/no-dupe-class-members': 'error',
+    },
 }

--- a/eslint-ts.js
+++ b/eslint-ts.js
@@ -1,6 +1,6 @@
 module.exports = {
     "extends": [
-        "maven",
+        "./index.js",
         // disable eslint rules that conflict with @typescript-eslint
         'plugin:@typescript-eslint/eslint-recommended',
         // new projects should consider enabling these plugins from the start

--- a/eslint-ts.js
+++ b/eslint-ts.js
@@ -3,6 +3,10 @@ module.exports = {
         "maven",
         // disable eslint rules that conflict with @typescript-eslint
         'plugin:@typescript-eslint/eslint-recommended',
+        // new projects should consider enabling these plugins from the start
+        // 'eslint:recommended',
+        // 'plugin:@typescript-eslint/recommended',
+        // 'plugin:@typescript-eslint/recommended-requiring-type-checking',
     ],
     "env": {
         "node": true
@@ -24,5 +28,18 @@ module.exports = {
         // Enable typescript version of rules originally from eslint
         // https://github.com/typescript-eslint/typescript-eslint/tree/v5.15.0/packages/eslint-plugin/docs/rules#extension-rules
         '@typescript-eslint/no-dupe-class-members': 'error',
+
+        // high-precision rules from plugin:@typescript-eslint/recommended
+        // and plugin:@typescript-eslint/recommended-requiring-type-checking
+        // https://github.com/typescript-eslint/typescript-eslint/tree/v5.15.0/packages/eslint-plugin#supported-rules
+        '@typescript-eslint/no-extra-non-null-assertion': 'error',
+        '@typescript-eslint/no-for-in-array': 'error',
+        '@typescript-eslint/no-floating-promises': 'error',
+        '@typescript-eslint/no-misused-new': 'error',
+        '@typescript-eslint/no-misused-promises': 'error',
+        '@typescript-eslint/no-namespace': 'error',
+        '@typescript-eslint/no-non-null-asserted-optional-chain': 'error',
+        '@typescript-eslint/no-var-requires': 'error',
+        '@typescript-eslint/prefer-namespace-keyword': 'error',
     },
 }

--- a/index.js
+++ b/index.js
@@ -1,61 +1,13 @@
 module.exports = {
-    extends: ['prettier'],
-    plugins: ['prettier'],
-    env: {
-        browser: true,
-        node: true,
-    },
-    // extra globals for the Angular part of the codebase.
-    globals: {
-        angular: true,
-        define: true,
-    },
-    rules: {
-        'max-len': [
-            'error',
-            {
-                code: 110,
-                ignoreStrings: true,
-                ignoreUrls: true,
-            },
-        ],
-        'prettier/prettier': [
-            'error',
-            require('./.prettierrc'),
-        ],
-
-        // enable a subset of eslint:recommended; consider enabling all of it
-        // https://eslint.org/docs/rules/
-        // When adding a rule here, also check whether you have to add
-        // the typescript version in eslint-ts.js
-        'getter-return': 'error',
-        'no-async-promise-executor': 'error',
-        'no-compare-neg-zero': 'error',
-        'no-const-assign': 'error',
-        'no-this-before-super': 'error',
-        'no-class-assign': 'error',
-        'no-dupe-args': 'error',
-        'no-dupe-class-members': 'error',
-        'no-dupe-else-if': 'error',
-        'no-dupe-keys': 'error',
-        'no-duplicate-case': 'error',
-        'no-fallthrough': 'error',
-        'no-func-assign': 'error',
-        'no-import-assign': 'error',
-        'no-setter-return': 'error',
-        'no-sparse-arrays': 'error',
-        'use-isnan': 'error',
-
-        'one-var': 'off',
-        'spaced-comment': 'off',
-        'no-useless-escape': 'off', // TODO should probably be on, with our errors fixed
-        'prefer-promise-reject-errors': 'off', // TODO consider fixing
-        'no-unneeded-ternary': 'off', // TODO should probably be on, with our errors fixed
-        'no-useless-return': 'off',
-        'new-cap': 'off',
-        'no-path-concat': 'off',
-        'no-throw-literal': 'off', // TODO should probably be on, with our errors fixed
-        'no-template-curly-in-string': 'off',
-        yoda: 'off',
-    },
+    extends: ['./eslint-js.js'],
+    overrides: [
+        // add no-op overrides as an alternative to passing --ext in the CLI
+        {
+            files: ['*.cjs', '*.mjs', '*.jsx'],
+        },
+        {
+            files: ['*.ts', '*.tsx'],
+            extends: ['./eslint-ts.js'],
+        },
+    ],
 };

--- a/index.js
+++ b/index.js
@@ -23,6 +23,29 @@ module.exports = {
             'error',
             require('./.prettierrc'),
         ],
+
+        // enable a subset of eslint:recommended; consider enabling all of it
+        // https://eslint.org/docs/rules/
+        // When adding a rule here, also check whether you have to add
+        // the typescript version in eslint-ts.js
+        'getter-return': 'error',
+        'no-async-promise-executor': 'error',
+        'no-compare-neg-zero': 'error',
+        'no-const-assign': 'error',
+        'no-this-before-super': 'error',
+        'no-class-assign': 'error',
+        'no-dupe-args': 'error',
+        'no-dupe-class-members': 'error',
+        'no-dupe-else-if': 'error',
+        'no-dupe-keys': 'error',
+        'no-duplicate-case': 'error',
+        'no-fallthrough': 'error',
+        'no-func-assign': 'error',
+        'no-import-assign': 'error',
+        'no-setter-return': 'error',
+        'no-sparse-arrays': 'error',
+        'use-isnan': 'error',
+
         'one-var': 'off',
         'spaced-comment': 'off',
         'no-useless-escape': 'off', // TODO should probably be on, with our errors fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "^4.31.2",
-        "@typescript-eslint/parser": "^4.31.2",
+        "@typescript-eslint/eslint-plugin": "^5.14.0",
+        "@typescript-eslint/parser": "^5.14.0",
         "eslint-config-prettier": "^8.3.0",
         "eslint-plugin-import": "^2.24.2",
         "eslint-plugin-node": "^11.1.0",
@@ -217,29 +217,30 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+      "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
       "dependencies": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/type-utils": "5.14.0",
+        "@typescript-eslint/utils": "5.14.0",
+        "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
+        "regexpp": "^3.2.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^4.0.0",
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
+        "@typescript-eslint/parser": "^5.0.0",
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "typescript": {
@@ -247,20 +248,59 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+    "node_modules/@typescript-eslint/parser": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+      "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
       "dependencies": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "eslint-scope": "^5.1.1",
-        "eslint-utils": "^3.0.0"
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
+        "debug": "^4.3.2"
       },
       "engines": {
-        "node": "^10.12.0 || >=12.0.0"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+      "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/type-utils": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+      "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
+      "dependencies": {
+        "@typescript-eslint/utils": "5.14.0",
+        "debug": "^4.3.2",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -268,9 +308,75 @@
       },
       "peerDependencies": {
         "eslint": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-utils": {
+    "node_modules/@typescript-eslint/types": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+      "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw==",
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+      "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
+      "dependencies": {
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@typescript-eslint/utils": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+      "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
+      "dependencies": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
+        "eslint-scope": "^5.1.1",
+        "eslint-utils": "^3.0.0"
+      },
+      "engines": {
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-utils": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
       "integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
@@ -287,7 +393,7 @@
         "eslint": ">=5"
       }
     },
-    "node_modules/@typescript-eslint/experimental-utils/node_modules/eslint-visitor-keys": {
+    "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
       "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
@@ -295,96 +401,16 @@
         "node": ">=10"
       }
     },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^5.0.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
-      },
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==",
-      "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-      "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      },
-      "engines": {
-        "node": "^10.12.0 || >=12.0.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+      "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
       "dependencies": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.14.0",
+        "eslint-visitor-keys": "^3.0.0"
       },
       "engines": {
-        "node": "^8.10.0 || ^10.13.0 || >=11.10.1"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -392,11 +418,11 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-      "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+      "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==",
       "engines": {
-        "node": ">=10"
+        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
     "node_modules/acorn": {
@@ -1153,9 +1179,9 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "node_modules/fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "dependencies": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -1164,7 +1190,7 @@
         "micromatch": "^4.0.4"
       },
       "engines": {
-        "node": ">=8"
+        "node": ">=8.6.0"
       }
     },
     "node_modules/fast-json-stable-stringify": {
@@ -1316,15 +1342,15 @@
       }
     },
     "node_modules/globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "dependencies": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       },
       "engines": {
@@ -1398,9 +1424,9 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "node_modules/ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ==",
       "engines": {
         "node": ">= 4"
       }
@@ -1541,9 +1567,9 @@
       }
     },
     "node_modules/is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "dependencies": {
         "is-extglob": "^2.1.1"
       },
@@ -1986,9 +2012,9 @@
       }
     },
     "node_modules/picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
       "engines": {
         "node": ">=8.6"
       },
@@ -2120,9 +2146,9 @@
       }
     },
     "node_modules/regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "engines": {
         "node": ">=8"
       },
@@ -2505,6 +2531,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/typescript": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.1.tgz",
@@ -2755,29 +2794,79 @@
       "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4="
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz",
-      "integrity": "sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.14.0.tgz",
+      "integrity": "sha512-ir0wYI4FfFUDfLcuwKzIH7sMVA+db7WYen47iRSaCGl+HMAZI9fpBwfDo45ZALD3A45ZGyHWDNLhbg8tZrMX4w==",
       "requires": {
-        "@typescript-eslint/experimental-utils": "4.33.0",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "debug": "^4.3.1",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/type-utils": "5.14.0",
+        "@typescript-eslint/utils": "5.14.0",
+        "debug": "^4.3.2",
         "functional-red-black-tree": "^1.0.1",
         "ignore": "^5.1.8",
-        "regexpp": "^3.1.0",
+        "regexpp": "^3.2.0",
         "semver": "^7.3.5",
         "tsutils": "^3.21.0"
       }
     },
-    "@typescript-eslint/experimental-utils": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.33.0.tgz",
-      "integrity": "sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==",
+    "@typescript-eslint/parser": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.14.0.tgz",
+      "integrity": "sha512-aHJN8/FuIy1Zvqk4U/gcO/fxeMKyoSv/rS46UXMXOJKVsLQ+iYPuXNbpbH7cBLcpSbmyyFbwrniLx5+kutu1pw==",
       "requires": {
-        "@types/json-schema": "^7.0.7",
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
+        "debug": "^4.3.2"
+      }
+    },
+    "@typescript-eslint/scope-manager": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.14.0.tgz",
+      "integrity": "sha512-LazdcMlGnv+xUc5R4qIlqH0OWARyl2kaP8pVCS39qSL3Pd1F7mI10DbdXeARcE62sVQE4fHNvEqMWsypWO+yEw==",
+      "requires": {
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0"
+      }
+    },
+    "@typescript-eslint/type-utils": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.14.0.tgz",
+      "integrity": "sha512-d4PTJxsqaUpv8iERTDSQBKUCV7Q5yyXjqXUl3XF7Sd9ogNLuKLkxz82qxokqQ4jXdTPZudWpmNtr/JjbbvUixw==",
+      "requires": {
+        "@typescript-eslint/utils": "5.14.0",
+        "debug": "^4.3.2",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.14.0.tgz",
+      "integrity": "sha512-BR6Y9eE9360LNnW3eEUqAg6HxS9Q35kSIs4rp4vNHRdfg0s+/PgHgskvu5DFTM7G5VKAVjuyaN476LCPrdA7Mw=="
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.14.0.tgz",
+      "integrity": "sha512-QGnxvROrCVtLQ1724GLTHBTR0lZVu13izOp9njRvMkCBgWX26PKvmMP8k82nmXBRD3DQcFFq2oj3cKDwr0FaUA==",
+      "requires": {
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/visitor-keys": "5.14.0",
+        "debug": "^4.3.2",
+        "globby": "^11.0.4",
+        "is-glob": "^4.0.3",
+        "semver": "^7.3.5",
+        "tsutils": "^3.21.0"
+      }
+    },
+    "@typescript-eslint/utils": {
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.14.0.tgz",
+      "integrity": "sha512-EHwlII5mvUA0UsKYnVzySb/5EE/t03duUTweVy8Zqt3UQXBrpEVY144OTceFKaOe4xQXZJrkptCf7PjEBeGK4w==",
+      "requires": {
+        "@types/json-schema": "^7.0.9",
+        "@typescript-eslint/scope-manager": "5.14.0",
+        "@typescript-eslint/types": "5.14.0",
+        "@typescript-eslint/typescript-estree": "5.14.0",
         "eslint-scope": "^5.1.1",
         "eslint-utils": "^3.0.0"
       },
@@ -2797,58 +2886,19 @@
         }
       }
     },
-    "@typescript-eslint/parser": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-4.33.0.tgz",
-      "integrity": "sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==",
-      "requires": {
-        "@typescript-eslint/scope-manager": "4.33.0",
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/typescript-estree": "4.33.0",
-        "debug": "^4.3.1"
-      }
-    },
-    "@typescript-eslint/scope-manager": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.33.0.tgz",
-      "integrity": "sha512-5IfJHpgTsTZuONKbODctL4kKuQje/bzBRkwHE8UOZ4f89Zeddg+EGZs8PD8NcN4LdM3ygHWYB3ukPAYjvl/qbQ==",
-      "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0"
-      }
-    },
-    "@typescript-eslint/types": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.33.0.tgz",
-      "integrity": "sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ=="
-    },
-    "@typescript-eslint/typescript-estree": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.33.0.tgz",
-      "integrity": "sha512-rkWRY1MPFzjwnEVHsxGemDzqqddw2QbTJlICPD9p9I9LfsO8fdmfQPOX3uKfUaGRDFJbfrtm/sXhVXN4E+bzCA==",
-      "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "@typescript-eslint/visitor-keys": "4.33.0",
-        "debug": "^4.3.1",
-        "globby": "^11.0.3",
-        "is-glob": "^4.0.1",
-        "semver": "^7.3.5",
-        "tsutils": "^3.21.0"
-      }
-    },
     "@typescript-eslint/visitor-keys": {
-      "version": "4.33.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.33.0.tgz",
-      "integrity": "sha512-uqi/2aSz9g2ftcHWf8uLPJA70rUv6yuMW5Bohw+bwcuzaxQIHaKFZCKGoGXIrc9vkTJ3+0txM73K0Hq3d5wgIg==",
+      "version": "5.14.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.14.0.tgz",
+      "integrity": "sha512-yL0XxfzR94UEkjBqyymMLgCBdojzEuy/eim7N9/RIcTNxpJudAcqsU8eRyfzBbcEzGoPWfdM3AGak3cN08WOIw==",
       "requires": {
-        "@typescript-eslint/types": "4.33.0",
-        "eslint-visitor-keys": "^2.0.0"
+        "@typescript-eslint/types": "5.14.0",
+        "eslint-visitor-keys": "^3.0.0"
       },
       "dependencies": {
         "eslint-visitor-keys": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
-          "integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw=="
+          "version": "3.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
+          "integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
         }
       }
     },
@@ -3413,9 +3463,9 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w=="
     },
     "fast-glob": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.7.tgz",
-      "integrity": "sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.11.tgz",
+      "integrity": "sha512-xrO3+1bxSo3ZVHAnqzyuewYT6aMFHRAd4Kcs92MAonjwQZLsK9d0SF1IyQ3k5PoirxTW0Oe/RqFgMQ6TcNE5Ew==",
       "requires": {
         "@nodelib/fs.stat": "^2.0.2",
         "@nodelib/fs.walk": "^1.2.3",
@@ -3543,15 +3593,15 @@
       }
     },
     "globby": {
-      "version": "11.0.4",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.4.tgz",
-      "integrity": "sha512-9O4MVG9ioZJ08ffbcyVYyLOJLk5JQ688pJ4eMGLpdWLHq/Wr1D9BlriLQyL0E+jbkuePVZXYFj47QM/v093wHg==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
+      "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
       "requires": {
         "array-union": "^2.1.0",
         "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
+        "fast-glob": "^3.2.9",
+        "ignore": "^5.2.0",
+        "merge2": "^1.4.1",
         "slash": "^3.0.0"
       }
     },
@@ -3598,9 +3648,9 @@
       "integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw=="
     },
     "ignore": {
-      "version": "5.1.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
-      "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.0.tgz",
+      "integrity": "sha512-CmxgYGiEPCLhfLnpPp1MoRmifwEIOgjcHXxOBjv7mY96c+eWScsOP9c112ZyLdWHi0FxHjI+4uVhKYp/gcdRmQ=="
     },
     "import-fresh": {
       "version": "3.3.0",
@@ -3696,9 +3746,9 @@
       "peer": true
     },
     "is-glob": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
-      "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
       "requires": {
         "is-extglob": "^2.1.1"
       }
@@ -4029,9 +4079,9 @@
       }
     },
     "picomatch": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
-      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="
     },
     "pify": {
       "version": "3.0.0",
@@ -4110,9 +4160,9 @@
       }
     },
     "regexpp": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.1.0.tgz",
-      "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q=="
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
+      "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg=="
     },
     "require-from-string": {
       "version": "2.0.2",
@@ -4383,6 +4433,12 @@
       "version": "0.20.2",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
       "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
+      "peer": true
+    },
+    "typescript": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "peer": true
     },
     "unbox-primitive": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eslint-config-maven",
+  "name": "@themaven-net/eslint-config-maven",
   "version": "1.0.0",
   "description": "TheMaven's eslint config",
   "main": "./index.js",

--- a/package.json
+++ b/package.json
@@ -26,8 +26,8 @@
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-promise": "^4.3.1",
-    "@typescript-eslint/eslint-plugin": "^4.31.2",
-    "@typescript-eslint/parser": "^4.31.2",
+    "@typescript-eslint/eslint-plugin": "^5.14.0",
+    "@typescript-eslint/parser": "^5.14.0",
     "prettier": "^2.3.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "eslint-config-maven",
   "version": "1.0.0",
   "description": "TheMaven's eslint config",
-  "main": "index.js",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js",
+    "./base-tsconfig.json": "./base-tsconfig.json",
+    "./.prettierrc": "./.prettierrc",
+    "./*": null
+  },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "./*": null
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "lint": "eslint .",
+    "test": "npm run lint"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
[PA-926](https://mavencorp.atlassian.net/browse/PA-926) Add additional recommended rules to eslint-maven that can catch common mistakes

Enable a subset of `eslint:recommended`, `plugin:@typescript-eslint/recommended`, and `plugin:@typescript-eslint/recommended-requiring-type-checking`

Enable a high-precision subset of eslint:recommended that have few false positives. There are other useful rules (e.g. no-unused-vars, no-undef) but they probably require more effort to enable

Enable several recommended rules from @typescript-eslint:

Enable no-floating-promises, which finds statements that might result in UnhandledPromiseRejectionWarning. Usually these promises should be awaited so that the error will be propagated to the caller. If you don’t want to await it, you can explicitly wrap it in void().

Enable no-misused-promises, which identifies promises used in conditionals; they should be awaited first. It also identifies async functions that are used where functions returning void are expected; they should be converted to non-async functions that wrap the async function.

Enable no-extra-non-null-assertion, no-for-in-array, no-misused-new, no-non-null-asserted-optional-chain, which identify common mistakes with few false positives.

Enable no-namespace, prefer-namespace-keyword, which discourage deprecated TypeScript features

Other recommended rules are more opinionated (no-empty-interface, no-inferrable-types, no-unnecessary-type-assertion, no-unnecessary-type-constraint, prefer-as-const) or difficult to enable (no-explicit-any, no-non-null-assertion, no-this-alias, no-unsafe-argument, no-unsafe-assignment, no-unsafe-call, no-unsafe-member-access, no-unsafe-return, restrict-plus-operands, restrict-template-expressions, triple-slash-reference, unbound-method). Please consider extending plugin:@typescript-eslint/recommended and plugin:@typescript-eslint/recommended-requiring-type-checking on new projects.

## Should eslint-config-maven contain more aggressive rules?

Ideally, I think we should enable more of `eslint:recommended`, `plugin:@typescript-eslint/recommended`, and `plugin:@typescript-eslint/recommended-requiring-type-checking`. But they would require more effort. In particular:
Here are useful rules from [eslint:recommended](https://eslint.org/docs/rules/) that I did *not* enable because they would have a lot of code changes. But in greenfield development we should probably enable them:
* [no-undef](https://eslint.org/docs/rules/no-undef) disallow the use of undeclared variables unless mentioned in `/*global */` comments
* [no-unreachable](https://eslint.org/docs/rules/no-unreachable) disallow unreachable code after `return`, `throw`, `continue`, and `break` statements
* [no-unused-vars](https://eslint.org/docs/rules/no-unused-vars) disallow unused variables

Here are useful rules from [@typescript-eslint](https://github.com/typescript-eslint/typescript-eslint/tree/v5.15.0/packages/eslint-plugin/docs/rules#supported-rules)/`recommended` or `recommended-requiring-type-checking` that I did *not* enable because they would have a lot of code changes. But in greenfield development we should probably enable them:
* no-explicit-any Disallow usage of the `any` type
* no-non-null-assertion Disallows non-null assertions using the `!` postfix operator
* no-this-alias Disallow aliasing `this`
* no-unsafe-argument Disallows calling a function with an `any` type value
* no-unsafe-assignment Disallows assigning `any` to variables and properties
* no-unsafe-call Disallows calling an `any` type value
* no-unsafe-member-access Disallows member access on `any` typed variables
* no-unsafe-return Disallows returning `any` from a function
* restrict-plus-operands When adding two variables, operands must both be of type number or of type string
* restrict-template-expressions Enforce template literal expressions to be of string type
* triple-slash-reference Sets preference level for triple slash directives versus ES6-style import declarations
* unbound-method Enforces unbound methods are called with their expected scope
