### PR TITLE
TEMPEST-9151 in ts lint no yoda

### DIFF
--- a/eslint-js.js
+++ b/eslint-js.js
@@ -53,6 +53,6 @@ module.exports = {
         'no-path-concat': 'off',
         'no-throw-literal': 'off', // TODO should probably be on, with our errors fixed
         'no-template-curly-in-string': 'off',
-        yoda: 'off',
+        yoda: ['error', 'never', { onlyEquality: true }],
     },
 };


### PR DESCRIPTION
This change disables ['yoda' conditions](https://eslint.org/docs/latest/rules/yoda#onlyequality) in equality comparisons, with the aim of improving readability and consistency throughout our codebases.

Applying this rule and updating the eslint config in consumers would require
- 2 changes in phoenix
- 0 changes in syndication-service (at the time of writing; a syndication PR is what brought this up)
- 0 changes in tempest-common
- 0 changes in chilliwack

I haven't checked other repos that are not listed above. Upgrading is opt in, so any repos with more dramatic effects can decide when/if to handle these style-only changes.