### PR TITLE
Use trailingComma: all

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,6 +1,6 @@
 module.exports = {
     printWidth: 110,
     tabWidth: 4,
-    trailingComma: 'es5',
+    trailingComma: 'all',
     singleQuote: true,
 };


### PR DESCRIPTION
WISOTT. I noticed that prettier removed a trailing comma in https://github.com/themaven-net/taiga/pull/1017/files#diff-cff838e38101043ea5962f05b9feab5ed4a65dd14793d4e148d19d05a1be4ea5R37, which led me to the discovery of this configuration key. Apparently it's going to be the default in Prettier 3 (https://prettier.io/docs/en/options.html#trailing-commas).