### PR TITLE
build: update publish config

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -44,7 +44,7 @@ jobs:
             echo >&2 "Error: the pushed tag $GITHUB_REF did not match package.json $VERSION; aborting npm publish"
             exit 2
           fi
-      - run: yarn publish
+      - run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -47,6 +47,7 @@ jobs:
       - run: yarn npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,5 +16,13 @@ jobs:
         with:
           node-version: '24'
           cache: 'yarn'
+          scope: '@themaven-net'
+          registry-url: 'https://npm.pkg.github.com'
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn install --frozen-lockfile
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - run: yarn test
+        env:
+          NPM_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,7 @@
 nodeLinker: node-modules
 
+npmAlwaysAuth: true
+npmAuthToken: ${NPM_TOKEN}
+npmPublishRegistry: "https://npm.pkg.github.com"
+
 yarnPath: .yarn/releases/yarn-4.12.0.cjs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@themaven-net/eslint-config-maven",
-    "version": "12.0.0",
+    "version": "12.0.2",
     "type": "module",
     "description": "TheMaven's eslint config",
     "main": "./index.js",


### PR DESCRIPTION
Config updates to support yarn v4 migration.
- build: update ci command for yarn v4
- build: update registry settings in yarnrc
- build: NPM_TOKEN added to env

__ref__
- https://yarnpkg.com/migration/guide#cli-changes
- https://yarnpkg.com/migration/guide#breaking-changes
- https://yarnpkg.com/configuration/yarnrc

__testing__
locally published `12.0.2-beta-0` via `yarn npm publish --tag beta`
https://github.com/themaven-net/eslint-config-maven/pkgs/npm/eslint-config-maven